### PR TITLE
Refactor CalendarList and ExpandableCalendar to streamline scrolling functionality

### DIFF
--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -164,6 +164,18 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
     }
   }, [current]);
 
+  const scrollToMonth = useCallback(
+    (date: XDate | string) => {
+      const scrollTo = parseDate(date);
+      const diffMonths = Math.round(initialDate?.current?.clone().setDate(1).diffMonths(scrollTo?.clone().setDate(1)));
+      const scrollAmount = calendarSize * (shouldFixRTL ? pastScrollRange - diffMonths : pastScrollRange + diffMonths);
+
+      if (scrollAmount !== 0) {
+        list?.current?.scrollToOffset({offset: scrollAmount, animated: animateScroll});
+      }
+    },
+    [calendarSize, shouldFixRTL, pastScrollRange, animateScroll]
+  );
   useDidUpdate(() => {
     const currMont = currentMonth?.clone();
     if (currMont) {
@@ -195,19 +207,6 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
       list?.current?.scrollToOffset({offset: scrollAmount, animated});
     }
   };
-
-  const scrollToMonth = useCallback(
-    (date: XDate | string) => {
-      const scrollTo = parseDate(date);
-      const diffMonths = Math.round(initialDate?.current?.clone().setDate(1).diffMonths(scrollTo?.clone().setDate(1)));
-      const scrollAmount = calendarSize * (shouldFixRTL ? pastScrollRange - diffMonths : pastScrollRange + diffMonths);
-
-      if (scrollAmount !== 0) {
-        list?.current?.scrollToOffset({offset: scrollAmount, animated: animateScroll});
-      }
-    },
-    [calendarSize, shouldFixRTL, pastScrollRange, animateScroll]
-  );
 
   const addMonth = useCallback(
     (count: number) => {
@@ -331,8 +330,12 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
           setCurrentMonth(visibleMonth.current);
         }
       }
+      if (scrollEnabled) {
+        const dates = viewableItems.map(item => xdateToData(parseDate(item.item)));
+        onVisibleMonthsChange?.(dates);
+      }
     },
-    [items, shouldFixRTL, current]
+    [items, shouldFixRTL, current, scrollEnabled]
   );
 
   const viewabilityConfigCallbackPairs = useRef([

--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -182,9 +182,19 @@ const ExpandableCalendar = forwardRef<ExpandableCalendarRef, ExpandableCalendarP
   };
 
   useEffect(() => {
+    /** Scroll */
+    const scrollToDate = (date: string) => {
+      if (!horizontal) {
+        calendarList?.current?.scrollToDay(date, 0, true);
+      } else if (getYear(date) !== visibleYear.current || getMonth(date) !== visibleMonth.current) {
+        // don't scroll if the month is already visible
+        calendarList?.current?.scrollToMonth(date);
+      }
+    };
+
     // date was changed from AgendaList, arrows or scroll
     scrollToDate(date);
-  }, [date]);
+  }, [date, horizontal]);
 
   /** Number of weeks */
 
@@ -322,17 +332,6 @@ const ExpandableCalendar = forwardRef<ExpandableCalendarRef, ExpandableCalendarP
     setScreenReaderEnabled(screenReaderEnabled);
     if (!screenReaderEnabled) {
       setHeaderHeight(DEFAULT_HEADER_HEIGHT);
-    }
-  };
-
-  /** Scroll */
-
-  const scrollToDate = (date: string) => {
-    if (!horizontal) {
-      calendarList?.current?.scrollToDay(date, 0, true);
-    } else if (getYear(date) !== visibleYear.current || getMonth(date) !== visibleMonth.current) {
-      // don't scroll if the month is already visible
-      calendarList?.current?.scrollToMonth(date);
     }
   };
 


### PR DESCRIPTION
- Moved the scrollToMonth function from CalendarList to a more appropriate location, improving code organization.
- Enhanced the scrollToDate function in ExpandableCalendar to prevent unnecessary scrolling when the month is already visible.
- Updated dependencies in the useEffect hook to ensure proper functionality with the new scrolling logic.